### PR TITLE
Support using the model's specified connection rather than application default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ tmtags
 ## VIM
 *.swp
 
+## IntelliJ/Rubymine
+.idea
+
 ## PROJECT::GENERAL
 coverage
 rdoc

--- a/lib/postgresql_cursor.rb
+++ b/lib/postgresql_cursor.rb
@@ -116,7 +116,6 @@ end
 
 # Defines extension to ActiveRecord to use this library
 class ActiveRecord::Base
-  
   # Public: Returns each row as a hash to the given block
   #
   # sql         - Full SQL statement, variables interpolated
@@ -128,6 +127,7 @@ class ActiveRecord::Base
   #
   # Returns the number of rows yielded to the block
   def self.each_row_by_sql(sql, options={}, &block)
+    options = {:connection => self.connection}.merge(options)
     PostgreSQLCursor.new(sql, options).each(&block)
   end
 
@@ -138,6 +138,7 @@ class ActiveRecord::Base
   #
   # Returns the number of rows yielded to the block
   def self.each_instance_by_sql(sql, options={}, &block)
+    options = {:connection => self.connection}.merge(options)
     PostgreSQLCursor.new(sql, options).each do |row|
       model = instantiate(row)
       yield model
@@ -159,7 +160,8 @@ class ActiveRecord::Relation
   #
   # Returns the number of rows yielded to the block
   def each_row(options={}, &block)
-    PostgreSQLCursor.new(to_sql).each(&block)
+    options = {:connection => self.connection}.merge(options)
+    PostgreSQLCursor.new(to_sql, options).each(&block)
   end
 
   # Public: Like each_row, but returns an instantiated model object to the block
@@ -168,6 +170,7 @@ class ActiveRecord::Relation
   #
   # Returns the number of rows yielded to the block
   def each_instance(options={}, &block)
+    options = {:connection => self.connection}.merge(options)
     PostgreSQLCursor.new(to_sql, options).each do |row|
       model = instantiate(row)
       yield model


### PR DESCRIPTION
In models you may wish to do something like

```
class Userstats < ActiveRecord::Base
  establish_connection "analysis_#{Rails.env}"
```

postgresql_cursor should respect the connection specified in the model. This patch implements defaulting to the model's connection.
