### PR TITLE
Avoid exception when closing cursor

### DIFF
--- a/lib/postgresql_cursor/cursor.rb
+++ b/lib/postgresql_cursor/cursor.rb
@@ -181,7 +181,9 @@ module PostgreSQLCursor
 
     # Public: Closes the cursor
     def close
-      @connection.execute("close cursor_#{@cursor}")
+      suppress(::ActiveRecord::StatementInvalid) do
+        @connection.execute("close cursor_#{@cursor}")
+      end
     end
 
     # Private: Sets the PostgreSQL cursor_tuple_fraction value = 1.0 to assume all rows will be fetched

--- a/test/test_postgresql_cursor.rb
+++ b/test/test_postgresql_cursor.rb
@@ -60,6 +60,14 @@ class TestPostgresqlCursor < Minitest::Test
     end
   end
 
+  def test_exception_raised_by_active_record
+    begin
+      Product.each_row_by_sql("SELECT * FROM unknown_table") {}
+    rescue => e
+      assert e.message.match('PG::UndefinedTable')
+    end
+  end
+
   def test_cursor
     cursor = Product.all.each_row
     assert cursor.respond_to?(:each)
@@ -78,5 +86,5 @@ class TestPostgresqlCursor < Minitest::Test
     assert_equal 1000, r.size
     assert_equal Fixnum, r.first.class
   end
-  
+
 end


### PR DESCRIPTION
If the original SQL statement is invalid, closing the cursor would raise a PG::InFailedSqlTransaction, masking the original error.

Fixes https://github.com/afair/postgresql_cursor/issues/14