### PR TITLE
support iterating the result set as an array

### DIFF
--- a/test/test_postgresql_cursor.rb
+++ b/test/test_postgresql_cursor.rb
@@ -31,6 +31,14 @@ class TestPostgresqlCursor < Minitest::Test
     assert_equal 1000, n
   end
 
+  def test_each_array
+    c = PostgreSQLCursor::Cursor.new("select * from products where id = 1")
+    c.each_array do |ary|
+      assert_equal Array, ary.class
+      assert_equal 1, ary[0].to_i
+    end
+  end
+
   def test_relation
     nn = 0
     Product.where("id>0").each_row {|r| nn += 1 }


### PR DESCRIPTION
Hi there, this PR adds the ability to retrieve an array of column values instead of a row hash.  The array format simplifies things for me slightly as I'm dealing with queries from (trusted!) users.

Thanks for this gem!