### PR TITLE
pluck_rows, pluck_instances queries projection with specified columns

### DIFF
--- a/lib/postgresql_cursor/active_record/relation/cursor_iterators.rb
+++ b/lib/postgresql_cursor/active_record/relation/cursor_iterators.rb
@@ -60,6 +60,7 @@ module PostgreSQLCursor
 
         private
 
+        # Returns sql string like #to_sql, but projection node is replaced by specified columns
         def to_pluck_sql(cols)
           self.arel.projections = cols.map {|col|
             Arel::Nodes::SqlLiteral.new(col.to_s)

--- a/lib/postgresql_cursor/active_record/relation/cursor_iterators.rb
+++ b/lib/postgresql_cursor/active_record/relation/cursor_iterators.rb
@@ -42,21 +42,15 @@ module PostgreSQLCursor
           cursor.iterate_type(self)
         end
 
-        # Plucks the column names from the rows, and return them in an array
+        # Plucks the specified column(s), and return them in an array
         def pluck_rows(*cols)
           options = cols.last.is_a?(Hash) ? cols.pop : {}
           options[:connection] = self.connection
           PostgreSQLCursor::Cursor.new(to_pluck_sql(cols), options).pluck(*cols)
         end
         alias :pluck_row :pluck_rows
-
-        # Plucks the column names from the instances, and return them in an array
-        def pluck_instances(*cols)
-          options = cols.last.is_a?(Hash) ? cols.pop : {}
-          options[:connection] = self.connection
-          PostgreSQLCursor::Cursor.new(to_pluck_sql(cols), options).iterate_type(self).pluck(*cols)
-        end
-        alias :pluck_instance :pluck_instances
+        alias :pluck_instance :pluck_rows
+        alias :pluck_insntaces :pluck_rows
 
         private
 


### PR DESCRIPTION
`pluck_rows` and `pluck_instances` always query like `select * from ...`, but most of the cases using `pluck`, users need to query like `select column_a, column_b, ... from...`.

Actually I don't know if it's good or bad to rewrite `arel.projection` object of ActiveRecord::Relation directly, but I would appreciate if you considered.

```
> Item.where('description like ?', '%R2-D2%').pluck_rows(:id, :description).first(10)
   (0.2ms)  BEGIN
   (0.4ms)  declare cursor_7 cursor for SELECT id, description FROM "items" WHERE (description like '%R2-D2%')
   (3.7ms)  fetch 1000 from cursor_7
   (0.1ms)  fetch 1000 from cursor_7
   (0.1ms)  close cursor_7
   (0.1ms)  COMMIT
=> [["3", "R2-D2, you know better than to trust a strange computer!"],
 ["5", "R2-D2, you know better than to trust a strange computer!"],
...
```
