### PR TITLE
Do not open transaction when with_hold option set to true

### DIFF
--- a/lib/postgresql_cursor/cursor.rb
+++ b/lib/postgresql_cursor/cursor.rb
@@ -134,7 +134,7 @@ module PostgreSQLCursor
       has_do_while  = @options.has_key?(:while)
       @count        = 0
       @column_types = nil
-      @connection.transaction do
+      with_optional_transaction do
         begin
           open
           while (row = fetch) do
@@ -210,6 +210,15 @@ module PostgreSQLCursor
     # Public: Closes the cursor
     def close
       @connection.execute("close cursor_#{@cursor}")
+    end
+
+    # Private: Open transaction unless with_hold option, specified
+    def with_optional_transaction
+      if @options[:with_hold]
+        yield
+      else
+        @connection.transaction { yield }
+      end
     end
 
     # Private: Sets the PostgreSQL cursor_tuple_fraction value = 1.0 to assume all rows will be fetched


### PR DESCRIPTION
As postgresql [documentation](https://www.postgresql.org/docs/9.5/static/sql-declare.html
 ) states:
 > Thus, DECLARE without WITH HOLD is useless outside a transaction block: the cursor would survive only to the completion of the statement. Therefore PostgreSQL reports an error if such a command is used outside a transaction block.

There are no need to keep open transaction if we want to do batch processing.