### PR TITLE
Fix OID reference when building unknown column type

### DIFF
--- a/lib/postgresql_cursor/cursor.rb
+++ b/lib/postgresql_cursor/cursor.rb
@@ -1,3 +1,5 @@
+require 'active_record/connection_adapters/postgresql/oid'
+
 ################################################################################
 # PostgreSQLCursor: library class provides postgresql cursor for large result
 # set processing. Requires ActiveRecord, but can be adapted to other DBI/ORM libraries.
@@ -17,6 +19,14 @@
 #   ActiveRecordModel.each_row_by_sql("select ...") { |hash| ... }
 #   ActiveRecordModel.each_instance_by_sql("select ...") { |model| ... }
 #
+
+
+if ::ActiveRecord::VERSION::MAJOR <= 4
+  OID = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::OID
+else
+  OID = ActiveRecord::ConnectionAdapters::PostgreSQL::OID
+end
+
 module PostgreSQLCursor
   class Cursor
     include Enumerable


### PR DESCRIPTION
Would fail with `NameError: uninitialized constant PostgreSQLCursor::Cursor::OID`.