### PR TITLE
Add batch iterators

### DIFF
--- a/lib/postgresql_cursor/active_record/sql_cursor.rb
+++ b/lib/postgresql_cursor/active_record/sql_cursor.rb
@@ -74,6 +74,80 @@ module PostgreSQLCursor
         cursor.iterate_type(self)
       end
 
+      # Public: Executes the query, yielding an array of up to block_size rows
+      # where each row is a hash to the given block.
+      #
+      # Parameters: same as each_row
+      #
+      # Example:
+      #   Post.each_row_batch { |batch| Post.process_batch(batch) }
+      #
+      # Returns the number of rows yielded to the block
+      def each_row_batch(options={}, &block)
+        options = {:connection => self.connection}.merge(options)
+        all.each_row_batch(options, &block)
+      end
+      alias :each_hash_batch :each_row_batch
+
+      # Public: Like each_row_batch, but yields an array of instantiated model
+      # objects to the block
+      #
+      # Parameters: same as each_row
+      #
+      # Example:
+      #   Post.each_instance_batch { |batch| Post.process_batch(batch) }
+      #
+      # Returns the number of rows yielded to the block
+      def each_instance_batch(options={}, &block)
+        options = {:connection => self.connection}.merge(options)
+        all.each_instance_batch(options, &block)
+      end
+
+      # Public: Yields each batch of up to block_size rows as an array of rows
+      # where each row as a hash to the given block
+      #
+      # Parameters: see each_row_by_sql
+      #
+      # Example:
+      #   Post.each_row_batch_by_sql("select * from posts") do |batch|
+      #     Post.process_batch(batch)
+      #   end
+      #   Post.each_row_batch_by_sql("select * from posts").map do |batch|
+      #     Post.transform_batch(batch)
+      #   end
+      #
+      # Returns the number of rows yielded to the block
+      def each_row_batch_by_sql(sql, options={}, &block)
+        options = {:connection => self.connection}.merge(options)
+        cursor  = PostgreSQLCursor::Cursor.new(sql, options)
+        return cursor.each_row_batch(&block) if block_given?
+        cursor.iterate_batched
+      end
+      alias :each_hash_batch_by_sql :each_row_batch_by_sql
+
+      # Public: Yields each batch up to block_size of rows as model instances
+      # to the given block
+      #
+      # As this instantiates a model object, it is slower than each_row_batch_by_sql
+      #
+      # Paramaters: see each_row_by_sql
+      #
+      # Example:
+      #   Post.each_instance_batch_by_sql("select * from posts") do |batch|
+      #     Post.process_batch(batch)
+      #   end
+      #   Post.each_instance_batch_by_sql("select * from posts").map do |batch|
+      #     Post.transform_batch(batch)
+      #   end
+      #
+      # Returns the number of rows yielded to the block
+      def each_instance_batch_by_sql(sql, options={}, &block)
+        options = {:connection => self.connection}.merge(options)
+        cursor  = PostgreSQLCursor::Cursor.new(sql, options)
+        return cursor.each_instance_batch(self, &block) if block_given?
+        cursor.iterate_type(self).iterate_batched
+      end
+
       # Returns and array of the given column names. Use if you need cursors and don't expect
       # this to comsume too much memory. Values are strings. Like ActiveRecord's pluck.
       def pluck_rows(*cols)

--- a/lib/postgresql_cursor/active_record/sql_cursor.rb
+++ b/lib/postgresql_cursor/active_record/sql_cursor.rb
@@ -148,7 +148,7 @@ module PostgreSQLCursor
         cursor.iterate_type(self).iterate_batched
       end
 
-      # Returns and array of the given column names. Use if you need cursors and don't expect
+      # Returns an array of the given column names. Use if you need cursors and don't expect
       # this to comsume too much memory. Values are strings. Like ActiveRecord's pluck.
       def pluck_rows(*cols)
         options = cols.last.is_a?(Hash) ? cols.pop : {}
@@ -156,7 +156,7 @@ module PostgreSQLCursor
       end
       alias :pluck_row :pluck_rows
 
-      # Returns and array of the given column names. Use if you need cursors and don't expect
+      # Returns an array of the given column names. Use if you need cursors and don't expect
       # this to comsume too much memory. Values are instance types. Like ActiveRecord's pluck.
       def pluck_instances(*cols)
         options = cols.last.is_a?(Hash) ? cols.pop : {}

--- a/lib/postgresql_cursor/cursor.rb
+++ b/lib/postgresql_cursor/cursor.rb
@@ -43,6 +43,7 @@ module PostgreSQLCursor
       @connection = @options.fetch(:connection) { ::ActiveRecord::Base.connection }
       @count      = 0
       @iterate    = options[:instances] ? :each_instance : :each_row
+      @batched    = false
     end
 
     # Specify the type to instantiate, or reset to return a Hash
@@ -58,6 +59,11 @@ module PostgreSQLCursor
       self
     end
 
+    def iterate_batched(batched=true)
+      @batched = batched
+      self
+    end
+
     # Public: Yields each row of the result set to the passed block
     #
     # Yields the row to the block. The row is a hash with symbolized keys.
@@ -66,11 +72,11 @@ module PostgreSQLCursor
     # Returns the count of rows processed
     def each(&block)
       if @iterate == :each_row
-        self.each_row(&block)
+        @batched ? self.each_row_batch(&block) : self.each_row(&block)
       elsif @iterate == :each_array
-        self.each_array(&block)
+        @batched ? self.each_array_batch(&block) : self.each_array(&block)
       else
-        self.each_instance(@type, &block)
+        @batched ? self.each_instance_batch(@type, &block) : self.each_instance(@type, &block)
       end
     end
 
@@ -104,6 +110,41 @@ module PostgreSQLCursor
           model = klass.send(:instantiate, row, @column_types)
         end
         block.call(model)
+      end
+    end
+
+    def each_row_batch(&block)
+      self.each_batch do |batch|
+        batch.map!(&:symbolize_keys) if @options[:symbolize_keys]
+        block.call(batch)
+      end
+    end
+
+    def each_array_batch(&block)
+      old_iterate = @iterate
+      @iterate = :each_array
+      begin
+        rv = self.each_batch do |batch|
+          block.call(batch)
+        end
+      ensure
+        @iterate = old_iterate
+      end
+      rv
+    end
+
+    def each_instance_batch(klass=nil, &block)
+      klass ||= @type
+      self.each_batch do |batch|
+        models = batch.map do |row|
+          if ::ActiveRecord::VERSION::MAJOR < 4
+            model = klass.send(:instantiate, row)
+          else
+            @column_types ||= column_types
+            model = klass.send(:instantiate, row, @column_types)
+          end
+        end
+        block.call(models)
       end
     end
 
@@ -145,6 +186,28 @@ module PostgreSQLCursor
           end
         rescue Exception => e
           raise e
+        ensure
+          close if @block
+        end
+      end
+      @count
+    end
+
+    def each_batch(&block) #:nodoc:
+      has_do_until = @options.key?(:until)
+      has_do_while = @options.key?(:while)
+      @count = 0
+      @column_types = nil
+      with_optional_transaction do
+        begin
+          open
+          while (batch = fetch_block)
+            break if batch.empty?
+            @count += 1
+            rc = block.call(batch)
+            break if has_do_until && rc == @options[:until]
+            break if has_do_while && rc != @options[:while]
+          end
         ensure
           close if @block
         end

--- a/test/test_postgresql_cursor.rb
+++ b/test/test_postgresql_cursor.rb
@@ -30,12 +30,12 @@ class TestPostgresqlCursor < Minitest::Test
 
   def test_each_while_until
     c = PostgreSQLCursor::Cursor.new("select * from products order by 1", until:true)
-    n = c.each { |r| r[:id].to_i > 100 }
-    assert_equal 1000, n
+    n = c.each { |r| r['id'].to_i > 100 }
+    assert_equal 101, n
 
     c = PostgreSQLCursor::Cursor.new("select * from products order by 1", while:true)
-    n = c.each { |r| r[:id].to_i < 100 }
-    assert_equal 1000, n
+    n = c.each { |r| r['id'].to_i < 100 }
+    assert_equal 100, n
   end
 
   def test_each_batch_while_until


### PR DESCRIPTION
Equivalent to find_in_batches, add iterator methods to yield rows in
batches

This can be useful for example when loading related models from another data store.

Examples:

```rb
Post.each_instance_batch(block_size: 100) do |batch|
  authors = External::User.where(id: batch.map(&:author_id)).index_by(&:id)
  batch.each do |post|
    author = authors[post.author_id]
    Post.process(post, author)
  end
end

Post.each_row_batch do |batch|
  Post.process_batch(batch)
end

Post.where('id>0').each_array_batch.map { |b| b.map { |ary| ary.first } }

Post.each_row_batch_by_sql('select * from posts') do |batch|
  Post.process_batch(batch)
end

Post.each_instance_batch_by_sql('select * from posts') do |batch|
  authors = External::User.where(id: batch.map(&:author_id)).index_by(&:id)
  batch.each do |post|
    author = authors[post.author_id]
    Post.process(post, author)
  end
end
```