### PR TITLE
Avoid referencing the AR connection adapter in the toplevel

### DIFF
--- a/lib/postgresql_cursor/cursor.rb
+++ b/lib/postgresql_cursor/cursor.rb
@@ -1,5 +1,3 @@
-require 'active_record/connection_adapters/postgresql/oid'
-
 ################################################################################
 # PostgreSQLCursor: library class provides postgresql cursor for large result
 # set processing. Requires ActiveRecord, but can be adapted to other DBI/ORM libraries.
@@ -19,13 +17,6 @@ require 'active_record/connection_adapters/postgresql/oid'
 #   ActiveRecordModel.each_row_by_sql("select ...") { |hash| ... }
 #   ActiveRecordModel.each_instance_by_sql("select ...") { |model| ... }
 #
-
-
-if ::ActiveRecord::VERSION::MAJOR <= 4
-  OID = ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::OID
-else
-  OID = ActiveRecord::ConnectionAdapters::PostgreSQL::OID
-end
 
 module PostgreSQLCursor
   class Cursor
@@ -240,7 +231,11 @@ module PostgreSQLCursor
         fmod  = @result.fmod i
         types[fname] = @connection.get_type_map.fetch(ftype, fmod) { |oid, mod|
           warn "unknown OID: #{fname}(#{oid}) (#{sql})"
-          OID::Identity.new
+          if ::ActiveRecord::VERSION::MAJOR <= 4
+            ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::OID::Identity.new
+          else
+            ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Identity.new
+          end
         }
       end
 


### PR DESCRIPTION
This PR fixes #41 not by documenting but by fixing the code.

[This implementation](https://github.com/afair/postgresql_cursor/blob/92224ba8e33df8da85b9c31ffdb56feb29390887/lib/postgresql_cursor/cursor.rb#L24-L28) expects AR postgresql connection adapter to be already loaded while loading this gem, but this assumption is not always true because AR usually loads the adapters after loading `config/database.yml` and datermining the database adapter to load.

Also, defining a global constant like this `OID` thing inside a gem is pretty rude. It may conflict with the users' application code or other gems.

This new constant has been introduced via #35 just for resolving an ambiguous `OID` constant refernce, but that ambiguity here could be more simply and naturally solved just by referencing the constant with the absolute path per each AR version.