### PR TITLE
Use ActiveSupport.on_load hook for defining anything on top of AR

### DIFF
--- a/lib/postgresql_cursor.rb
+++ b/lib/postgresql_cursor.rb
@@ -1,12 +1,14 @@
 require 'postgresql_cursor/version'
-require 'postgresql_cursor/cursor'
-require 'postgresql_cursor/active_record/relation/cursor_iterators'
-require 'postgresql_cursor/active_record/sql_cursor'
-require 'postgresql_cursor/active_record/connection_adapters/postgresql_type_map'
 
-# ActiveRecord 4.x
-require 'active_record'
-require 'active_record/connection_adapters/postgresql_adapter'
-ActiveRecord::Base.extend(PostgreSQLCursor::ActiveRecord::SqlCursor)
-ActiveRecord::Relation.send(:include, PostgreSQLCursor::ActiveRecord::Relation::CursorIterators)
-ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send(:include, PostgreSQLCursor::ActiveRecord::ConnectionAdapters::PostgreSQLTypeMap)
+ActiveSupport.on_load :active_record do
+  require 'postgresql_cursor/cursor'
+  require 'postgresql_cursor/active_record/relation/cursor_iterators'
+  require 'postgresql_cursor/active_record/sql_cursor'
+  require 'postgresql_cursor/active_record/connection_adapters/postgresql_type_map'
+
+  # ActiveRecord 4.x
+  require 'active_record/connection_adapters/postgresql_adapter'
+  ActiveRecord::Base.extend(PostgreSQLCursor::ActiveRecord::SqlCursor)
+  ActiveRecord::Relation.send(:include, PostgreSQLCursor::ActiveRecord::Relation::CursorIterators)
+  ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send(:include, PostgreSQLCursor::ActiveRecord::ConnectionAdapters::PostgreSQLTypeMap)
+end


### PR DESCRIPTION
Another reason that was causing problems like #41 is that this gem touches `ActiveRecord::Base` from the toplevel.
This should better be delayed until the application defines a model and loads `AR::Base`, and for that purpose, Rails has `ActiveSupport.on_load` mechanism.

This simple hook is indeed independent on Rails (Raities) since it's implemented in Active Support and triggered within `AR::Base` class, so it should work with non-Rails apps.