### PR TITLE
Value.new vs Identity.new

### DIFF
--- a/lib/postgresql_cursor/cursor.rb
+++ b/lib/postgresql_cursor/cursor.rb
@@ -240,7 +240,7 @@ module PostgreSQLCursor
         fmod  = @result.fmod i
         types[fname] = @connection.get_type_map.fetch(ftype, fmod) { |oid, mod|
           warn "unknown OID: #{fname}(#{oid}) (#{sql})"
-          OID::Identity.new
+          ::ActiveRecord::Type::Value.new
         }
       end
 

--- a/lib/postgresql_cursor/version.rb
+++ b/lib/postgresql_cursor/version.rb
@@ -1,3 +1,3 @@
 module PostgresqlCursor
-  VERSION = "0.6.2"
+  VERSION = "0.6.2_minus_identity"
 end

--- a/lib/postgresql_cursor/version.rb
+++ b/lib/postgresql_cursor/version.rb
@@ -1,3 +1,3 @@
 module PostgresqlCursor
-  VERSION = "0.6.2_minus_identity"
+  VERSION = "0.6.2.1"
 end


### PR DESCRIPTION
In newer versions of ActiveRecord, ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Identity has been replaced with ActiveRecord::Type::Value.

Unfortunately, postgresql_cursor gem has not been updated to take advantage of this, and throws an exception whenever it is the first piece of code that queries a column with an as yet unloaded postgresql column type.  (As it duplicates the prior internal behaviour of Rails which did the same thing)