### PR TITLE
Do not load association during initialization of cursor.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,4 +21,5 @@ desc "Setup testing database and table"
 task :setup do
   sh %q(createdb postgresql_cursor_test)
   sh %Q<echo "create table products ( id serial primary key, data varchar);" | psql postgresql_cursor_test>
+  sh %Q<echo "create table prices ( id serial primary key, data varchar, product_id integer);" | psql postgresql_cursor_test>
 end

--- a/lib/postgresql_cursor/cursor.rb
+++ b/lib/postgresql_cursor/cursor.rb
@@ -50,11 +50,14 @@ module PostgreSQLCursor
       @batched    = false
     end
 
-    # Specify the type to instantiate, or reset to return a Hash
+    # Specify the type to instantiate, or reset to return a Hash.
+    #
+    # Explicitly check for type class to prevent calling equality
+    # operator on active record relation, which will load it.
     def iterate_type(type=nil)
-      if type.nil? || type == Hash
+      if type.nil? || (type.class == Class && type == Hash)
         @iterate = :each_row
-      elsif type == Array
+      elsif type.class == Class && type == Array
         @iterate = :each_array
       else
         @iterate = :each_instance

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,12 +10,18 @@ ActiveRecord::Base.establish_connection(adapter: 'postgresql',
   username: ENV['TEST_USER']     || ENV['USER'] || 'postgresql_cursor')
 
 class Product < ActiveRecord::Base
+  has_many :prices
+
   # create table records (id serial primary key);
   def self.generate(max=1_000)
     max.times do |i|
       connection.execute("insert into products values (#{i+1})")
     end
   end
+end
+
+class Price < ActiveRecord::Base
+  belongs_to :product
 end
 
 Product.destroy_all

--- a/test/test_postgresql_cursor.rb
+++ b/test/test_postgresql_cursor.rb
@@ -191,4 +191,9 @@ class TestPostgresqlCursor < Minitest::Test
       assert_match(/bad_table/, e.message)
     end
   end
+
+  def test_relation_association_is_not_loaded
+    cursor = Product.first.prices.each_instance
+    refute cursor.instance_variable_get(:@type).loaded?
+  end
 end


### PR DESCRIPTION
Hello, I have spotted when cursor is used on association the association is actually loaded (sql query is triggered).

I have found out it is related to type check in `iterate_type`. Using `==` to compare type triggers the association query. I have added type check of `ŧype.class` to avoid calling equality operator on active record relation.

There's need to access `@type` via `instance_variable_get` on cursor in specs, but I think it is not worth it to expose `type` to public just because of specs.

## before (cursor is initialized and **prices relation is loaded**)

```ruby
[4] pry(#<TestPostgresqlCursor>)> cursor = Product.first.prices.each_instance;nil
D, [2020-01-17T00:14:47.381230 #1955109] DEBUG -- :   Product Load (0.7ms)  SELECT "products".* FROM "products" ORDER BY "products"."id" ASC LIMIT $1  [["LIMIT", 1]]
D, [2020-01-17T00:14:47.382515 #1955109] DEBUG -- :   Price Load (0.3ms)  SELECT "prices".* FROM "prices" WHERE "prices"."product_id" = $1  [["product_id", 1]]
=> nil

```

## after (cursor is initialized and **prices relation is not loaded**)

```ruby
[2] pry(#<TestPostgresqlCursor>)> cursor = Product.first.prices.each_instance;nil                                                                                                             
D, [2020-01-17T00:13:48.292153 #1954698] DEBUG -- :   Product Load (0.3ms)  SELECT "products".* FROM "products" ORDER BY "products"."id" ASC LIMIT $1  [["LIMIT", 1]]
=> nil                                                                                                                                                                                        

```