### PR TITLE
Skip closing cursor if connection held is no longer active

### DIFF
--- a/lib/postgresql_cursor/cursor.rb
+++ b/lib/postgresql_cursor/cursor.rb
@@ -194,7 +194,7 @@ module PostgreSQLCursor
         rescue Exception => e
           raise e
         ensure
-          close if @block
+          close if @block && connection.active?
         end
       end
       @count
@@ -216,7 +216,7 @@ module PostgreSQLCursor
             break if has_do_while && rc != @options[:while]
           end
         ensure
-          close if @block
+          close if @block && connection.active?
         end
       end
       @count

--- a/test/test_postgresql_cursor.rb
+++ b/test/test_postgresql_cursor.rb
@@ -130,6 +130,26 @@ class TestPostgresqlCursor < Minitest::Test
     assert_equal e.message, 'Oops'
   end
 
+  def test_exception_in_failed_transaction
+    begin
+      Product.each_row_by_sql("select * from products") do |r|
+        Product.connection.execute('select kaboom')
+      end
+    rescue Exception => e
+      assert_match(/kaboom/, e.message)
+    end
+  end
+
+  def test_batch_exception_in_failed_transaction
+    begin
+      Product.each_row_batch_by_sql("select * from products") do |r|
+        Product.connection.execute('select kaboom')
+      end
+    rescue Exception => e
+      assert_match(/kaboom/, e.message)
+    end
+  end
+
   def test_cursor
     cursor = Product.all.each_row
     assert cursor.respond_to?(:each)


### PR DESCRIPTION
It avoids issues when a transaction fails, thus the statement to close the cursor will fail.
In addition this obscures the underlying error in the user code due to raising when closing the cursor.

The tests show a toy case of when/how this can occur, however I've ran into similar issues where I wasn't able to figure out the error from application logs since the error I would get would be the one raised from the `ensure` block.

An alternative approach would be to actually nest a begin/rescue in the ensure block and rescue error to avoid obscuring the underlying error, or be more precise and rescue only `ActiveRecord::StatementInvalid`. If that is preferred, I could change this PR.