### PR TITLE
NoMethodError when using Ruby 3.2 

### DIFF
--- a/lib/postgresql_cursor/cursor.rb
+++ b/lib/postgresql_cursor/cursor.rb
@@ -231,8 +231,8 @@ module PostgreSQLCursor
       fields.each_with_index do |fname, i|
         ftype = @result.ftype i
         fmod = @result.fmod i
-        types[fname] = @connection.get_type_map.fetch(ftype, fmod) do |oid, mod|
-          warn "unknown OID: #{fname}(#{oid}) (#{sql})"
+        types[fname] = @connection.get_type_map.fetch(ftype.to_s, fmod) do |oid, mod|
+          # warn "unknown OID: #{fname}(#{oid}, #{mod}) (#{sql})"
           if ::ActiveRecord::VERSION::MAJOR <= 4
             ::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::OID::Identity.new
           else


### PR DESCRIPTION
Attempting to run this gem with Ruby 3.2 results in exceptions like this:

```
NoMethodError: undefined method `=~' for -1:Integer
    /Users/jturkel/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activerecord-7.0.4/lib/active_record/connection_adapters/abstract_adapter.rb:734:in `extract_limit'
    /Users/jturkel/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activerecord-7.0.4/lib/active_record/connection_adapters/abstract_adapter.rb:710:in `block in register_class_with_limit'
    /Users/jturkel/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activerecord-7.0.4/lib/active_record/type/hash_lookup_type_map.rb:53:in `perform_fetch'
    /Users/jturkel/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activerecord-7.0.4/lib/active_record/type/hash_lookup_type_map.rb:19:in `block in fetch'
    /Users/jturkel/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/concurrent-ruby-1.1.10/lib/concurrent-ruby/concurrent/map.rb:203:in `block in fetch_or_store'
    /Users/jturkel/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/concurrent-ruby-1.1.10/lib/concurrent-ruby/concurrent/map.rb:182:in `fetch'
    /Users/jturkel/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/concurrent-ruby-1.1.10/lib/concurrent-ruby/concurrent/map.rb:202:in `fetch_or_store'
    /Users/jturkel/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activerecord-7.0.4/lib/active_record/type/hash_lookup_type_map.rb:18:in `fetch'
    /Users/jturkel/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activerecord-7.0.4/lib/active_record/type/hash_lookup_type_map.rb:14:in `lookup'
    /Users/jturkel/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activerecord-7.0.4/lib/active_record/type/hash_lookup_type_map.rb:40:in `block in alias_type'
    /Users/jturkel/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activerecord-7.0.4/lib/active_record/type/hash_lookup_type_map.rb:53:in `perform_fetch'
    /Users/jturkel/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activerecord-7.0.4/lib/active_record/type/hash_lookup_type_map.rb:19:in `block in fetch'
    /Users/jturkel/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/concurrent-ruby-1.1.10/lib/concurrent-ruby/concurrent/map.rb:203:in `block in fetch_or_store'
    /Users/jturkel/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/concurrent-ruby-1.1.10/lib/concurrent-ruby/concurrent/map.rb:182:in `fetch'
    /Users/jturkel/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/concurrent-ruby-1.1.10/lib/concurrent-ruby/concurrent/map.rb:202:in `fetch_or_store'
    /Users/jturkel/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activerecord-7.0.4/lib/active_record/type/hash_lookup_type_map.rb:18:in `fetch'
    /Users/jturkel/code/postgresql_cursor/lib/postgresql_cursor/cursor.rb:234:in `block in column_types'
    /Users/jturkel/code/postgresql_cursor/lib/postgresql_cursor/cursor.rb:231:in `each'
    /Users/jturkel/code/postgresql_cursor/lib/postgresql_cursor/cursor.rb:231:in `each_with_index'
    /Users/jturkel/code/postgresql_cursor/lib/postgresql_cursor/cursor.rb:231:in `column_types'
    /Users/jturkel/code/postgresql_cursor/lib/postgresql_cursor/cursor.rb:116:in `block in each_instance'
    /Users/jturkel/code/postgresql_cursor/lib/postgresql_cursor/cursor.rb:189:in `block in each_tuple'
   ...
```
This problem can be reproduced by running the gem's test suite with Ruby 3.2.0 rather than Ruby 2.7.7.