### PR TITLE
Modernize supported dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ pkg
 
 ## PROJECT::SPECIFIC
 Gemfile.lock
+gemfiles/*.gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 rvm:
-  - 2.6.5
-  - 2.7.1
+  - 2.7.7
+  - 3.0.5
+  - 3.1.3
+  - 3.2.0
 before_install:
   - sudo apt-get update
   - sudo apt-get --yes remove postgresql\*
@@ -9,13 +11,9 @@ before_install:
   - sudo cp /etc/postgresql/{9.6,12}/main/pg_hba.conf
   - sudo service postgresql restart 12
 gemfile:
-  - gemfiles/activerecord_4.gemfile
-  - gemfiles/activerecord_5.gemfile
-  - gemfiles/activerecord_6.gemfile
-matrix:
-  exclude:
-    - rvm: 2.7.1
-      gemfile: gemfiles/activerecord_4.gemfile
+  - gemfiles/activerecord_6_0.gemfile
+  - gemfiles/activerecord_6_1.gemfile
+  - gemfiles/activerecord_7_0.gemfile
 services:
   - postgresql
 before_script:

--- a/Appraisals
+++ b/Appraisals
@@ -1,12 +1,11 @@
-appraise "activerecord-4" do
-  gem "activerecord", "4.2.11.1"
-  gem "pg", "~> 0.15"
+appraise "activerecord-6-0" do
+  gem "activerecord", "6.0.6"
 end
 
-appraise "activerecord-5" do
-  gem "activerecord", "5.2.3"
+appraise "activerecord-6-1" do
+  gem "activerecord", "6.1.7"
 end
 
-appraise "activerecord-6" do
-  gem "activerecord", "6.0.0"
+appraise "activerecord-7-0" do
+  gem "activerecord", "7.0.4"
 end

--- a/gemfiles/activerecord_6_0.gemfile
+++ b/gemfiles/activerecord_6_0.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "5.2.3"
+gem "activerecord", "6.0.6"
 
 gemspec path: "../"

--- a/gemfiles/activerecord_6_1.gemfile
+++ b/gemfiles/activerecord_6_1.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "6.0.0"
+gem "activerecord", "6.1.7"
 
 gemspec path: "../"

--- a/gemfiles/activerecord_7_0.gemfile
+++ b/gemfiles/activerecord_7_0.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "4.2.11.1"
-gem "pg", "~> 0.15"
+gem "activerecord", "7.0.4"
 
 gemspec path: "../"

--- a/lib/postgresql_cursor.rb
+++ b/lib/postgresql_cursor.rb
@@ -12,6 +12,6 @@ ActiveSupport.on_load :active_record do
   # ActiveRecord 4.x
   require 'active_record/connection_adapters/postgresql_adapter'
   ActiveRecord::Base.extend(PostgreSQLCursor::ActiveRecord::SqlCursor)
-  ActiveRecord::Relation.send(:include, PostgreSQLCursor::ActiveRecord::Relation::CursorIterators)
-  ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send(:include, PostgreSQLCursor::ActiveRecord::ConnectionAdapters::PostgreSQLTypeMap)
+  ActiveRecord::Relation.include(PostgreSQLCursor::ActiveRecord::Relation::CursorIterators)
+  ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.include(PostgreSQLCursor::ActiveRecord::ConnectionAdapters::PostgreSQLTypeMap)
 end

--- a/lib/postgresql_cursor/cursor.rb
+++ b/lib/postgresql_cursor/cursor.rb
@@ -110,12 +110,8 @@ module PostgreSQLCursor
     def each_instance(klass = nil, &block)
       klass ||= @type
       each_tuple do |row|
-        if ::ActiveRecord::VERSION::MAJOR < 4
-          model = klass.send(:instantiate, row)
-        else
-          @column_types ||= column_types
-          model = klass.send(:instantiate, row, @column_types)
-        end
+        @column_types ||= column_types
+        model = klass.send(:instantiate, row, @column_types)
         block.call(model)
       end
     end
@@ -144,12 +140,8 @@ module PostgreSQLCursor
       klass ||= @type
       each_batch do |batch|
         models = batch.map do |row|
-          if ::ActiveRecord::VERSION::MAJOR < 4
-            klass.send(:instantiate, row)
-          else
-            @column_types ||= column_types
-            klass.send(:instantiate, row, @column_types)
-          end
+          @column_types ||= column_types
+          klass.send(:instantiate, row, @column_types)
         end
         block.call(models)
       end
@@ -223,7 +215,6 @@ module PostgreSQLCursor
     end
 
     def column_types
-      return nil if ::ActiveRecord::VERSION::MAJOR < 4
       return @column_types if @column_types
 
       types = {}
@@ -233,11 +224,7 @@ module PostgreSQLCursor
         fmod = @result.fmod i
         types[fname] = @connection.get_type_map.fetch(ftype.to_s, fmod) do |oid, mod|
           # warn "unknown OID: #{fname}(#{oid}, #{mod}) (#{sql})"
-          if ::ActiveRecord::VERSION::MAJOR <= 4
-            ::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::OID::Identity.new
-          else
-            ::ActiveRecord::Type::Value.new
-          end
+          ::ActiveRecord::Type::Value.new
         end
       end
 

--- a/postgresql_cursor.gemspec
+++ b/postgresql_cursor.gemspec
@@ -27,14 +27,12 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.7'
+
   # Remove this for jruby which should use 'activerecord-jdbcpostgresql-adapter'
   # spec.add_dependency 'pg'
 
-  spec.add_dependency "activerecord", ">= 3.1.0"
-  # spec.add_dependency 'activerecord', '~> 3.1.0'
-  # spec.add_dependency 'activerecord', '~> 4.1.0'
-  # spec.add_dependency 'activerecord', '~> 5.0.0'
-  # spec.add_dependency 'activerecord', '~> 6.0.0'
+  spec.add_dependency "activerecord", ">= 6.0"
 
   spec.add_development_dependency "irb"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
This PR drops support for EOL Rubies (i.e. Ruby < 2.7) and EOL Rails (i.e. Rails < 6.0). It also adds every minor Ruby and Rails version to the test matrix. Travis wouldn't let me run tests on my fork since I don't have a paid plain but I updated the Travis config anyway. The propagation of exceptions from transactions changed a bit between Rails 6.x and Rails 7 so I had to tweak a few tests.