### PR TITLE
Remove early return from `set_cursor_tuple_fraction`

### DIFF
--- a/lib/postgresql_cursor/cursor.rb
+++ b/lib/postgresql_cursor/cursor.rb
@@ -292,12 +292,9 @@ module PostgreSQLCursor
     # This is a value between 0.1 and 1.0 (PostgreSQL defaults to 0.1, this library defaults to 1.0)
     # used to determine the expected fraction (percent) of result rows returned the the caller.
     # This value determines the access path by the query planner.
-    def set_cursor_tuple_fraction(frac = 1.0)
-      @cursor_tuple_fraction ||= @options.fetch(:fraction, 1.0)
-      return @cursor_tuple_fraction if frac == @cursor_tuple_fraction
-      @cursor_tuple_fraction = frac
-      @result = @connection.execute("set cursor_tuple_fraction to  #{frac}")
-      frac
+    def set_cursor_tuple_fraction
+      frac = @options.fetch(:fraction, 1.0)
+      @result = @connection.execute("set cursor_tuple_fraction to #{frac}")
     end
   end
 end


### PR DESCRIPTION
The early return removed the ability to override Postgres' default fraction of `0.1` with `1.0`. A workaround was to use `0.99999` but that's a little bit ugly, so let's just always set the tuple fraction.

Alternatively, we could check the current fraction on the `@connection` and only change it if it's different, which would also allow us to revert the temporary fraction change afterward, but that's an adjustment for another PR.

Partially fixes #49